### PR TITLE
Fix targetSdkVersion being loaded incorrectly

### DIFF
--- a/jdroid-gradle-android-plugin/src/main/groovy/com/jdroid/gradle/android/AndroidGradlePlugin.groovy
+++ b/jdroid-gradle-android-plugin/src/main/groovy/com/jdroid/gradle/android/AndroidGradlePlugin.groovy
@@ -34,7 +34,7 @@ public abstract class AndroidGradlePlugin extends JavaBaseGradlePlugin {
 
 		android.defaultConfig {
 			minSdkVersion jdroid.minimumSdkVersion
-			targetSdkVersion jdroid.getIntegerProp('ANDROID_BUILD_TOOLS_VERSION', ANDROID_SDK_VERSION)
+			targetSdkVersion jdroid.getIntegerProp('ANDROID_COMPILE_SDK_VERSION', ANDROID_SDK_VERSION)
 
 			vectorDrawables.useSupportLibrary = jdroid.getBooleanProp('VECTOR_DRAWABLES_USE_SUPPORT_LIB', true)
 


### PR DESCRIPTION
ANDROID_BUILD_TOOLS_VERSION was being used instead of ANDROID_COMPILE_SDK_VERSION